### PR TITLE
Add S4 — offline Android app for BIP-39 → SLIP-39 paper backup (Wallets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Your keys, your coins—if you pick the right wallet. Compare hot wallets, hardw
 | [OKX Wallet](https://cryptotoolsdirectory.com/tools/okx-wallet)           | 9.1 /10  | Hot      | Extension, Mobile     | Bitcoin, Ethereum, Solana, BNB Chain, OKTC, Polygon, Aptos, Sui, + 100 chains                | Web3 DApp hub, swaps/bridge, OKX exchange ecosystem                   |
 | [Safe{Wallet}](https://cryptotoolsdirectory.com/tools/safe-wallet)        | 9.3 /10  | Multisig | Web, Mobile           | Ethereum, Base, Arbitrum, Optimism, Polygon, Gnosis, Avalanche, BNB Chain, + other EVMs      | Multisig treasury control, team approvals, DAO/org wallets            |
 | [Rainbow](https://cryptotoolsdirectory.com/tools/rainbow)                 | 8.9 /10  | Hot      | Mobile, Extension     | Ethereum, Base, Optimism, Arbitrum, Polygon, Zora, + other EVMs                              | Clean Ethereum UX, NFT gallery, swaps, ENS-friendly design            |
+| [S4](https://github.com/heyaibi/s4)                          | 9.2 /10  | Hot      | Android               | Offline (no INTERNET)                                                                         | Offline SLIP-39 backup — splits any BIP-39 seed to 2-16 shares; 100% offline, GPL-3.0 |
 
 ---
 


### PR DESCRIPTION
S4 — offline Android app for BIP-39 → SLIP-39 paper backup (any wallet).

- **Comparison context:** Your Wallets table compares Hot/Hardware/Multisig for holding keys — S4 is the missing backup layer: splits any BIP-39 12/15/18/21/24-word seed or raw entropy into N SLIP-39 shares (2-16, threshold 1≤T≤N, default 6/any-3, 20-33 words each) via vendored bc-shamir/bc-slip39; restores exact seed from any T with SHA-256 fingerprint; provides verbatim Recovery Guide for decades-later restore via any SLIP-39 tool (iancoleman.io/slip39, Trezor, python-mnemonic). 100% offline (no INTERNET permission, FLAG_SECURE), Android (com.s4), GPL-3.0, 91 JVM + 35 instrumented tests.
- **Why Wallets:** Trezor row already notes "Shamir backup options" — S4 is the standalone SLIP-39 utility that creates those shares on Android, paper-only, for any BIP-39 wallet. Fills gap between hardware cold storage and hot wallets.
- **Source:** https://github.com/heyaibi/s4 — GPL-3.0, 100% offline, Android. Row: `| [S4](link) | 9.2/10 | Hot | Android | Offline (no INTERNET) | Offline SLIP-39 backup — splits any BIP-39 seed to 2-16 shares; 100% offline, GPL-3.0 |`.

Section: 👛 Crypto Wallets (append after Rainbow, format `| Wallet | Score | Type | Platforms | Network | Features |`). Happy to adjust score/type/placement — e.g., move to new "Seed Backup" sub-table if preferred.
