### PR TITLE
Add Deep Blue Alpha — Ethereum whale tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,3 +407,5 @@ This is a decentralized platform for trading futures and perpetual contracts. It
 ---
 
 ### How to Contribute
+
+- [Deep Blue Alpha](https://deepbluealpha.io) — Free Ethereum whale tracker with 20,000+ monitored wallets, real-time DEX swap classification, and daily intelligence reports.


### PR DESCRIPTION
Adds [Deep Blue Alpha](https://deepbluealpha.io) — a free, real-time Ethereum whale tracking platform.

- Tracks 20,000+ whale wallets with live DEX swap classification
- Whale Sentiment Index (daily buy/sell score)
- Free public API (no auth): `/api/v1/public/stats`, `/api/v1/public/whale-index`
- No signup, no wallet connection required

Live at [deepbluealpha.io](https://deepbluealpha.io).